### PR TITLE
Fixed Adaptive Tardis Exterior door 

### DIFF
--- a/src/main/java/loqor/ait/api/TardisEvents.java
+++ b/src/main/java/loqor/ait/api/TardisEvents.java
@@ -168,6 +168,19 @@ public final class TardisEvents {
                 return DoorHandler.InteractionResult.CONTINUE;
             });
 
+    public static final Event<DoorUsed> DOOR_USED = EventFactory.createArrayBacked(DoorUsed.class,
+            callbacks -> (tardis, player) -> {
+                for (DoorUsed callback : callbacks) {
+                    DoorHandler.InteractionResult result = callback.onDoorUsed(tardis, player);
+                    if (result == DoorHandler.InteractionResult.CONTINUE)
+                        continue;
+
+                    return result;
+                }
+
+                return DoorHandler.InteractionResult.CONTINUE;
+            });
+
     public static final Event<EnterTardis> ENTER_TARDIS = EventFactory.createArrayBacked(EnterTardis.class,
             callbacks -> (tardis, entity) -> {
                 for (EnterTardis callback : callbacks) {
@@ -428,6 +441,10 @@ public final class TardisEvents {
         DoorHandler.InteractionResult onUseDoor(Tardis tardis, ServerWorld interior, ServerWorld world, @Nullable ServerPlayerEntity player, @Nullable BlockPos pos);
     }
 
+    @FunctionalInterface
+    public interface DoorUsed {
+        DoorHandler.InteractionResult onDoorUsed(Tardis tardis, ServerPlayerEntity player);
+    }
     /**
      * Called when the interior door position is changed, meaning it was probably
      * moved

--- a/src/main/java/loqor/ait/core/tardis/handler/ChameleonHandler.java
+++ b/src/main/java/loqor/ait/core/tardis/handler/ChameleonHandler.java
@@ -67,7 +67,7 @@ public class ChameleonHandler extends TardisComponent {
             }
         });
 
-        TardisEvents.USE_DOOR.register((tardis, interior, world, player, pos) -> {
+        TardisEvents.DOOR_USED.register((tardis,  player) -> {
             if (player == null)
                 return DoorHandler.InteractionResult.CONTINUE;
 

--- a/src/main/java/loqor/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/loqor/ait/core/tardis/handler/DoorHandler.java
@@ -252,6 +252,8 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
         }
 
         this.setDoorState(this.getDoorState().next(doorSchema.isDouble()));
+
+        TardisEvents.DOOR_USED.invoker().onDoorUsed(tardis,player);
         return true;
     }
 


### PR DESCRIPTION
When The Adaptive Tardis Door is was closed, the disguise would disappear, and when it was open the disguise would appear. (The Opposite should be true)
Described in [This Issue](https://github.com/pavatus/ait/issues/849)

This was caused by a problem where the ChameleonHandler class wasn't getting up to date information on the door state because it was invoked by the USE_DOOR event, which ran before the door was actually updated. 

I've created a new event called DOOR_USED, which is invoked after the door interaction has finished, which fixes the issue.

